### PR TITLE
포스페이 다중 결제수단 연동 + 실 API 실측 반영 (백엔드)

### DIFF
--- a/controllers/pay.controller.js
+++ b/controllers/pay.controller.js
@@ -22,7 +22,7 @@ import { readPool, writePool } from "../config/db-pool.js";
 import crypto from 'crypto';
 import qs from 'qs';
 import { requestPayment, getStatusByOrderNo, cancelPayment } from "../utils.js/payments/payletter.js";
-import { createSession as forspayCreateSession, getLaunch as forspayGetLaunch, getTransaction as forspayGetTransaction, cancelTransaction as forspayCancelTransaction, verifyWebhookSignature as forspayVerifySig, FORSPAY_API_BASE } from "../utils.js/payments/forspay.js";
+import { createSession as forspayCreateSession, getLaunch as forspayGetLaunch, getTransaction as forspayGetTransaction, cancelTransaction as forspayCancelTransaction, verifyWebhookSignature as forspayVerifySig, getForspayMethod, FORSPAY_API_BASE } from "../utils.js/payments/forspay.js";
 import { encForSave } from "../utils.js/pii.js";
 
 
@@ -48,6 +48,7 @@ const payCtrl = {
         products = [],
         buyer_name,
         buyer_phone,
+        pay_method,        // 포스페이: 구매자가 고른 결제수단 키(card/bank/kakaopay/…)
         receiver,          // 배송지 받는사람
         addr_phone,        // 배송지 연락처
         zonecode,          // 우편번호
@@ -338,6 +339,16 @@ const payCtrl = {
           if (!FORSPAY_API_BASE || FORSPAY_API_BASE.includes('REPLACE')) {
             return response(req, res, -100, "포스페이 Base URL(FORSPAY_API_BASE) 설정이 필요합니다.", false);
           }
+          // 구매자가 고른 결제수단 → 포스페이 파라미터 매핑 (미지정 시 신용카드)
+          const fsMethod = getForspayMethod(pay_method) || getForspayMethod('card');
+          if (fsMethod?.pending) {
+            return response(req, res, -100, `'${fsMethod.label}'은(는) 아직 준비 중인 결제수단입니다. (협력사 확인 필요)`, false);
+          }
+          // PG(페이레터/나이스) 라우팅: 수단별 지정 → 모듈 기본(MID) → 미지정 시 포스페이 자동
+          const routedProvider = creds?.method_provider?.[fsMethod.key];
+          const fsProvider = (routedProvider !== undefined && routedProvider !== null && String(routedProvider).trim() !== '')
+            ? routedProvider
+            : creds.pg_provider_id;
           const front_url = (req.body.front_url || "").toString().trim();
           const backBase = `${req.protocol}://${req.get('host')}`;
           const order_no = String(ord_num || `FS${trans_id}`).replace(/[^a-zA-Z0-9]/g, '').slice(0, 64);
@@ -349,11 +360,15 @@ const payCtrl = {
             item_name: item_name || '상품',
             buyer_name,
             ord_num: order_no,
-            pg_method_id: 0,               // 인증결제 = 카드
-            pg_provider_id: creds.pg_provider_id,  // 비어있으면 포스페이 자동 라우팅
+            pg_method_id: fsMethod.pg_method_id,
+            route: fsMethod.route,
+            foreign_method: fsMethod.foreign_method,
+            pg_provider_id: fsProvider,    // 비어있으면 포스페이 자동 라우팅
             return_url,
             user_agent: req.body.user_agent || 'WP',
             buyer_phone,
+            buyer_email: req.body.buyer_email,
+            billaddrcity: req.body.billaddrcity,
           });
 
           let launch_page_url = session?.launch_page_url;
@@ -512,7 +527,16 @@ const payCtrl = {
 
       const decode_user = checkLevel(req.cookies.token, 0, res);
       const decode_dns = checkDns(req.cookies.dns);
-      const { trx_id, pay_key, amount, mid, tid, canAmt, canMsg, partCanFlg, encData, ediDate, id, pg } = req.body;
+      const { trx_id, pay_key, amount, mid, tid, canAmt, canMsg, partCanFlg, encData, ediDate, id } = req.body;
+      let { pg } = req.body;
+      // 프론트가 pg를 안 실어보내도, 거래의 trx_method로 결제사를 판별해 안전하게 라우팅
+      // (40=페이레터, 41=포스페이. 그 외는 기존 기본 취소 흐름 유지)
+      if (!pg && id) {
+        let pgRows = await readPool.query(`SELECT trx_method FROM transactions WHERE id=?`, [id]);
+        let tm = pgRows?.[0]?.[0]?.trx_method;
+        if (tm == 40) pg = 'payletter';
+        else if (tm == 41) pg = 'forspay';
+      }
       let files = settingFiles(req.files);
       let obj = {};
       const formData = qs.stringify({ trx_id, pay_key, amount, mid, tid, canAmt, canMsg, partCanFlg, encData, ediDate });
@@ -795,15 +819,26 @@ async function settlePayletterTransaction(transId, data = {}) {
 }
 
 // 브랜드별 포스페이 인증정보를 payment_modules(trx_type=41)에서 조회
-//  결제키(pay_key)=App key, MID=pg_provider_id(선택), TID=sign_key(선택)
+//  결제키(pay_key)=App key, MID=pg_provider_id(기본), TID=sign_key(선택)
+//  forspay_config(JSON, 선택)=수단별 PG 라우팅. 컬럼이 없어도 안전하도록 SELECT *.
 async function getForspayCreds(brand_id) {
   let rows = await readPool.query(
-    `SELECT mid, pay_key, tid FROM payment_modules WHERE brand_id=? AND trx_type=41 ORDER BY id DESC LIMIT 1`,
+    `SELECT * FROM payment_modules WHERE brand_id=? AND trx_type=41 ORDER BY id DESC LIMIT 1`,
     [brand_id]
   );
   let m = rows[0][0];
   if (!m) return null;
-  return { app_key: m.pay_key, pg_provider_id: m.mid, sign_key: m.tid };
+  // 수단별 PG 지정값(provider) 파싱: { card:1, wechat:4, ... }
+  let method_provider = {};
+  try {
+    const cfg = m.forspay_config ? JSON.parse(m.forspay_config) : {};
+    const methods = cfg?.methods || {};
+    for (const k of Object.keys(methods)) {
+      const p = methods[k]?.provider;
+      if (p !== undefined && p !== null && String(p).trim() !== '') method_provider[k] = p;
+    }
+  } catch (e) { method_provider = {}; }
+  return { app_key: m.pay_key, pg_provider_id: m.mid, sign_key: m.tid, method_provider };
 }
 
 // 포스페이 거래 확정(멱등): 거래조회로 승인 확인된 건을 결제완료 처리 + 포인트 적립
@@ -812,7 +847,14 @@ async function settleForspayTransaction(transId, data = {}) {
   let rows = await readPool.query(`SELECT * FROM transactions WHERE id=?`, [transId]);
   let trx = rows[0][0];
   if (!trx) return false;
-  if (trx.trx_status == 5) return true; // 이미 확정됨(중복 return/webhook 방지)
+  if (trx.trx_status == 5) {
+    // 이미 확정됨(중복 return/webhook 방지). 단, 카드번호는 거래조회 응답엔 없고 웹훅에만 있으므로
+    // 리턴 경로가 먼저 확정해 카드번호가 비어있으면, 뒤늦게 온 웹훅 데이터로 1회 보강한다.
+    if (!trx.card_num && data.card_num) {
+      await updateQuery('transactions', { card_num: String(data.card_num) }, transId);
+    }
+    return true;
+  }
 
   let trx_dttm = (data.trx_dttm || '').toString();
   let trx_dt = trx_dttm.includes(' ') ? trx_dttm.split(' ')[0] : trx_dttm;

--- a/controllers/payment_module.controller.js
+++ b/controllers/payment_module.controller.js
@@ -59,12 +59,13 @@ const paymentModuleCtrl = {
             const decode_user = checkLevel(req.cookies.token, 0, res);
             const decode_dns = checkDns(req.cookies.dns);
             const {
-                pay_key, mid, tid, trx_type = 0, is_old_auth = 0, brand_id, virtual_acct_url, virtual_acct_num, virtual_acct_name, virtual_acct_bank, gift_certificate_url
+                pay_key, mid, tid, trx_type = 0, is_old_auth = 0, brand_id, virtual_acct_url, virtual_acct_num, virtual_acct_name, virtual_acct_bank, gift_certificate_url, forspay_config
             } = req.body;
             let files = settingFiles(req.files);
             let obj = {
                 brand_id, pay_key, mid, tid, trx_type, is_old_auth, virtual_acct_url, virtual_acct_num, virtual_acct_name, virtual_acct_bank, gift_certificate_url
             };
+            if (forspay_config !== undefined) obj.forspay_config = forspay_config; // 포스페이 수단별 PG 라우팅(JSON). 컬럼 필요(ALTER).
             let columns = [
                 `${table_name}.*`,
             ]
@@ -94,13 +95,14 @@ const paymentModuleCtrl = {
             const decode_user = checkLevel(req.cookies.token, 0, res);
             const decode_dns = checkDns(req.cookies.dns);
             const {
-                pay_key, mid, tid, trx_type = 0, is_old_auth = 0, brand_id, virtual_acct_url, virtual_acct_num, virtual_acct_name, virtual_acct_bank, gift_certificate_url,
+                pay_key, mid, tid, trx_type = 0, is_old_auth = 0, brand_id, virtual_acct_url, virtual_acct_num, virtual_acct_name, virtual_acct_bank, gift_certificate_url, forspay_config,
                 id
             } = req.body;
             let files = settingFiles(req.files);
             let obj = {
                 pay_key, mid, tid, trx_type, is_old_auth, virtual_acct_url, virtual_acct_num, virtual_acct_name, virtual_acct_bank, gift_certificate_url
             };
+            if (forspay_config !== undefined) obj.forspay_config = forspay_config; // 포스페이 수단별 PG 라우팅(JSON). 컬럼 필요(ALTER).
             obj = { ...obj, ...files };
             let is_exist_trx_type = await readPool.query(`SELECT * FROM ${table_name} WHERE trx_type=? AND brand_id=? AND id!=?`, [trx_type, decode_dns?.id ?? 0, id]);
             is_exist_trx_type = is_exist_trx_type[0];

--- a/controllers/shop.controller.js
+++ b/controllers/shop.controller.js
@@ -2,6 +2,7 @@
 import { checkIsManagerUrl, getMainObjType, returnMoment } from "../utils.js/function.js";
 import { deleteQuery, getMultipleQueryByWhen, getSelectQueryList } from "../utils.js/query-util.js";
 import { categoryDepth, checkDns, checkLevel, findChildIds, findParent, homeItemsSetting, homeItemsWithCategoriesSetting, isItemBrandIdSameDnsId, lowLevelException, makeObjByList, makeTree, makeUserToken, response, getPayType } from "../utils.js/util.js";
+import { FORSPAY_METHODS } from "../utils.js/payments/forspay.js";
 import 'dotenv/config';
 import productCtrl from "./product.controller.js";
 import postCtrl from "./post.controller.js";
@@ -279,12 +280,35 @@ const shopCtrl = {
                 }
             })
 
-            //결제모듈처리
-            data['payment_modules'] = data?.payment_modules.map((item) => {
-                return {
-                    ...item,
-                    ...getPayType(item?.trx_type)
+            //결제모듈처리 (포스페이(41)는 활성 결제수단별 옵션으로 분리 — 구매자가 수단 선택)
+            data['payment_modules'] = (data?.payment_modules || []).flatMap((item) => {
+                if (item?.trx_type != 41) {
+                    return [{ ...item, ...getPayType(item?.trx_type) }];
                 }
+                // 수단별 노출 설정(enabled) 파싱. 설정 없으면 pending(삼성페이) 제외 전부 노출.
+                let methodsCfg = {};
+                try {
+                    const cfg = item?.forspay_config ? JSON.parse(item.forspay_config) : {};
+                    methodsCfg = cfg?.methods || {};
+                } catch (e) { methodsCfg = {}; }
+                const base = getPayType(item?.trx_type); // type: 'auth_forspay'
+                // 비밀값(App key 등)은 프론트로 내보내지 않는다 — 화이트리스트 필드만 구성
+                return FORSPAY_METHODS
+                    .filter((m) => {
+                        const mc = methodsCfg[m.key];
+                        if (mc && typeof mc.enabled !== 'undefined') return !!mc.enabled;
+                        return !m.pending;
+                    })
+                    .map((m) => ({
+                        id: item?.id,
+                        trx_type: item?.trx_type,
+                        is_old_auth: item?.is_old_auth,
+                        sort_idx: item?.sort_idx,
+                        ...base,
+                        title: `포스페이 · ${m.label}`,
+                        description: '안전한 결제를 위해 포스페이 결제창으로 이동합니다.',
+                        pay_method: m.key,
+                    }));
             })
 
             //상품카테고리처리

--- a/utils.js/payments/forspay.js
+++ b/utils.js/payments/forspay.js
@@ -11,22 +11,43 @@ import crypto from 'crypto';
  *   - MID            = pg_provider_id (선택, 특정 PG 고정용. 비우면 포스페이 자동 라우팅)
  *   - TID            = sign_key (선택, 웹훅 서명 검증용)
  *
- * ★ Base URL: 협력사(포스페이)가 발급하는 공개 API 호스트({oms-host})로 교체하세요.
- *   테스트/운영 호스트가 다릅니다. 값을 받으면 아래 상수(또는 env FORSPAY_API_BASE)만 바꾸면 됩니다.
+ * ★ Base URL: 테스트 호스트 = https://api.forspay.net (2026-07-30 협력사 제공, ping 200 확인).
+ *   운영 호스트가 다를 수 있으니 전환 시 이 상수(또는 env FORSPAY_API_BASE) 교체.
+ *   ※ 경로 주의: 문서에는 /api/v1/samw/... 로 돼 있으나 실제 서버는 samw 없이 /api/v1/... 로 동작함(실측 확인).
  */
-export const FORSPAY_API_BASE = process.env.FORSPAY_API_BASE || 'https://REPLACE_WITH_OMS_HOST';
+export const FORSPAY_API_BASE = process.env.FORSPAY_API_BASE || 'https://api.forspay.net';
 
 const authHeaders = (app_key) => ({
     'Content-Type': 'application/json',
     Authorization: `Bearer ${app_key}`,
 });
 
-// 체크아웃 세션 생성 (POST /api/v1/samw/checkout/sessions) — direct_pg_ui
+// ─────────────────────────────────────────────────────────────
+// 포스페이 결제수단 카탈로그 — 프론트 노출 + 백엔드 파라미터 매핑의 공용 단일 소스
+//   pg_method_id: 0=신용카드 1=실시간계좌이체 3=간편결제(+route) 5=해외결제(+foreign_method)
+//   route(간편결제): 0=카카오 1=네이버 3=라인   /   foreign_method(해외): card/alipay/wechat
+//   pending=true 는 협력사 확인 전이라 기본 비활성 (삼성페이: route 값 미정)
+// ─────────────────────────────────────────────────────────────
+export const FORSPAY_METHODS = [
+    { key: 'card',         label: '신용카드',        pg_method_id: 0 },
+    { key: 'bank',         label: '실시간계좌이체',  pg_method_id: 1 },
+    { key: 'kakaopay',     label: '카카오페이',      pg_method_id: 3, route: 0 },
+    { key: 'naverpay',     label: '네이버페이',      pg_method_id: 3, route: 1 },
+    { key: 'linepay',      label: '라인페이',        pg_method_id: 3, route: 3 },
+    { key: 'foreign_card', label: '해외발행카드',    pg_method_id: 5, foreign_method: 'card' },
+    { key: 'wechat',       label: '위챗페이',        pg_method_id: 5, foreign_method: 'wechat' },
+    { key: 'alipay',       label: '알리페이',        pg_method_id: 5, foreign_method: 'alipay' },
+    { key: 'samsungpay',   label: '삼성페이',        pg_method_id: 3, route: null, pending: true },
+];
+export const getForspayMethod = (key) => FORSPAY_METHODS.find((m) => m.key === String(key || '')) || null;
+
+// 체크아웃 세션 생성 (POST /api/v1/checkout/sessions) — direct_pg_ui
 export const createSession = async ({
     app_key, base = FORSPAY_API_BASE,
     amount, item_name, buyer_name, ord_num,
-    pg_method_id = 0, pg_provider_id, return_url,
-    user_agent = 'WP', buyer_phone, payment_currency = 'KRW',
+    pg_method_id = 0, pg_provider_id, route, foreign_method, return_url,
+    user_agent = 'WP', buyer_phone, buyer_email, billaddrcity,
+    payment_currency = 'KRW', currency, order_currency,
 } = {}) => {
     const body = {
         checkout_mode: 'direct_pg_ui',
@@ -42,8 +63,18 @@ export const createSession = async ({
     if (pg_provider_id !== undefined && pg_provider_id !== null && String(pg_provider_id).trim() !== '') {
         body.pg_provider_id = parseInt(pg_provider_id, 10);
     }
+    // 간편결제(pg_method_id=3) 하위 서비스: route (0=카카오 1=네이버 3=라인 …)
+    if (route !== undefined && route !== null && String(route).trim() !== '') {
+        body.route = parseInt(route, 10);
+    }
+    // 해외결제(pg_method_id=5) 하위 수단 및 통화/청구지
+    if (foreign_method) body.foreign_method = String(foreign_method);
+    if (currency) body.currency = String(currency).slice(0, 4);
+    if (order_currency) body.order_currency = String(order_currency).slice(0, 4);
+    if (buyer_email) body.buyer_email = String(buyer_email).slice(0, 100);   // 해외 카드 권장
+    if (billaddrcity) body.billaddrcity = String(billaddrcity).slice(0, 100); // 해외 카드 청구지
     if (buyer_phone) body.buyer_phone = String(buyer_phone).slice(0, 20);
-    const { data } = await axios.post(`${base}/api/v1/samw/checkout/sessions`, body, { headers: authHeaders(app_key) });
+    const { data } = await axios.post(`${base}/api/v1/checkout/sessions`, body, { headers: authHeaders(app_key) });
     return data;
 };
 
@@ -52,25 +83,25 @@ export const getLaunch = async ({ app_key, base = FORSPAY_API_BASE, order_code, 
     const body = {};
     if (return_url) body.return_url = return_url;
     if (user_agent) body.user_agent = user_agent;
-    const { data } = await axios.post(`${base}/api/v1/samw/checkout/sessions/${order_code}/pay`, body, { headers: authHeaders(app_key) });
+    const { data } = await axios.post(`${base}/api/v1/checkout/sessions/${order_code}/pay`, body, { headers: authHeaders(app_key) });
     return data;
 };
 
-// 거래 조회 (GET /api/v1/samw/transactions/{ord_num}?cxl_seq=0) — status: approved / cancelled
+// 거래 조회 (GET /api/v1/transactions/{ord_num}?cxl_seq=0) — status: approved / cancelled
 export const getTransaction = async ({ app_key, base = FORSPAY_API_BASE, ord_num, cxl_seq = 0 } = {}) => {
     const { data } = await axios.get(
-        `${base}/api/v1/samw/transactions/${encodeURIComponent(ord_num)}?cxl_seq=${cxl_seq}`,
+        `${base}/api/v1/transactions/${encodeURIComponent(ord_num)}?cxl_seq=${cxl_seq}`,
         { headers: authHeaders(app_key) }
     );
     return data;
 };
 
-// 거래 취소 (POST /api/v1/samw/transactions/{ord_num}/cancel). amount 생략 시 전액취소.
+// 거래 취소 (POST /api/v1/transactions/{ord_num}/cancel). amount 생략 시 전액취소.
 export const cancelTransaction = async ({ app_key, base = FORSPAY_API_BASE, ord_num, amount } = {}) => {
     const body = {};
     if (amount !== undefined && amount !== null && String(amount).trim() !== '') body.amount = parseInt(amount, 10);
     const { data } = await axios.post(
-        `${base}/api/v1/samw/transactions/${encodeURIComponent(ord_num)}/cancel`,
+        `${base}/api/v1/transactions/${encodeURIComponent(ord_num)}/cancel`,
         body,
         { headers: authHeaders(app_key) }
     );


### PR DESCRIPTION
- 결제수단별 pg_method_id/route/foreign_method 매핑, 카드 하드코딩 제거
- 수단별 PG 라우팅(forspay_config) + 매장 노출을 수단별 옵션으로 확장(shop.controller, App key 등 비밀값 미노출)
- Base URL=api.forspay.net 반영, 엔드포인트 경로 samw 제거(실서버 실측: 문서는 /api/v1/samw/… 이나 실제는 /api/v1/…)
- 결제취소 trx_method 기반 라우팅 보강(페이레터/포스페이)
- 확정 시 카드번호 웹훅 보강(거래조회 응답엔 card_num 없음)