### PR TITLE
포스페이 세션 생성 실패 시 실제 사유 로그·노출

### DIFF
--- a/controllers/pay.controller.js
+++ b/controllers/pay.controller.js
@@ -380,7 +380,9 @@ const payCtrl = {
             launch_page_url = launched?.launch_page_url;
           }
           if (!launch_page_url) {
-            return response(req, res, -100, session?.message || "포스페이 세션 생성 실패", false);
+            // 포스페이가 201로 오류바디(예: {"error":"No payment module configured..."})를 줄 수 있어, 실제 사유를 로그·노출
+            logger.error(`[forspay] launch_page_url 없음 — resp=${JSON.stringify(session)}`);
+            return response(req, res, -100, session?.message || session?.error || "포스페이 세션 생성 실패", false);
           }
 
           // return/webhook 매칭용 ord_num을 거래에 동기화(정규화 값)


### PR DESCRIPTION
포스페이가 201로 {error:...}(예: No payment module configured) 반환 시, launch_page_url 없음 분기에서 원문 로그 + session.error도 응답 메시지로 노출(진단 용이).