### PR TITLE
회원·주문 검색 오류(1270) 수정 — 암호화 PII 컬럼을 FULLTEXT 검색에서 제외

### DIFF
--- a/utils.js/search-columns.js
+++ b/utils.js/search-columns.js
@@ -9,18 +9,23 @@ export const searchColumns = {
 }
 
 // FULLTEXT 인덱스가 있는 같은 테이블 컬럼 (MATCH AGAINST 사용)
+// ※ transactions(buyer_name·buyer_phone), users(name·phone_num) 은 PII 암호화(Phase 4) 대상이라
+//    ① 값이 암호문이라 FULLTEXT 부분검색이 무의미하고,
+//    ② PII 컬럼 폭 확장 마이그레이션으로 collation이 달라져 MATCH 시
+//       'Illegal mix of collations'(ER_CANT_AGGREGATE_3COLLATIONS, 1270) 오류가 발생함.
+//    → 두 테이블을 FULLTEXT 대상에서 제외하고, 아래 likeOnlyColumns 평문 축으로 검색한다.
 export const fulltextColumns = {
     'products': ['product_name', 'product_comment', 'product_code'],
-    'transactions': ['buyer_name', 'appr_num', 'buyer_phone'],
-    'users': ['user_name', 'name', 'nickname', 'phone_num'],
 }
 
-// FULLTEXT 대상이 아닌 JOIN 테이블 컬럼 (LIKE 유지)
+// FULLTEXT 대상이 아닌 컬럼 (LIKE 사용) — 암호화되지 않은 '평문' 검색축.
 export const likeOnlyColumns = {
     'products': [`product_categories0.category_name`, `product_categories1.category_en_name`],
     'seller_adjustments': ['brands.name', 'users.name', 'users.nickname'],
-    // 주문검색 축 추가: 주문번호(ord_num) + 회원 아이디(users.user_name).
-    // 암호화(Phase 4)로 이름·전화 부분검색이 사라지는 것을 대체하는 평문 검색축.
-    // ※ users.user_name은 transactions list 쿼리가 users를 항상 JOIN해야 유효(transaction.controller.js).
-    'transactions': ['transactions.ord_num', 'users.user_name'],
+    // 주문검색 평문축: 주문번호(ord_num) · 회원 아이디(users.user_name) · 승인번호(appr_num).
+    //  이름·전화는 암호화되어 부분검색이 불가하므로 평문 축으로 대체한다.
+    //  ※ users.user_name 은 transactions list 쿼리가 users를 항상 JOIN해야 유효(transaction.controller.js).
+    'transactions': ['transactions.ord_num', 'users.user_name', 'transactions.appr_num'],
+    // 회원검색 평문축: 아이디(user_name) · 닉네임(nickname). 이름·전화는 암호화되어 부분검색 불가.
+    'users': ['users.user_name', 'users.nickname'],
 }


### PR DESCRIPTION
PII 암호화(Phase 4) 후 transactions(buyer_name·buyer_phone)·users(name·phone_num)가 암호문이 되고, PII 컬럼 폭 확장 마이그레이션으로 collation이 달라져 MATCH 시 'Illegal mix of collations'(ER_CANT_AGGREGATE_3COLLATIONS, 1270)로 관리자 회원/주문 검색이 실패했음.
- fulltextColumns에서 transactions·users 제거(products만 FULLTEXT 유지)
- 평문 검색축을 likeOnlyColumns로 대체: 주문=ord_num·user_name·appr_num, 회원=user_name·nickname