### PR TITLE
회원·주문 검색에 blind-index(정확일치) 축 추가 — 암호화된 이름·전화 검색 지원

### DIFF
--- a/utils.js/query-util.js
+++ b/utils.js/query-util.js
@@ -1,5 +1,6 @@
 import 'dotenv/config';
-import { searchColumns, fulltextColumns, likeOnlyColumns } from './search-columns.js';
+import { searchColumns, fulltextColumns, likeOnlyColumns, blindIndexColumns } from './search-columns.js';
+import { blindIndex } from './crypto-util.js';
 import { readPool, writePool } from '../config/db-pool.js';
 
 export const insertQuery = async (table, obj) => {
@@ -212,6 +213,16 @@ const settingSelectQueryWhere = (sql_, query, table, find_columns = [], wherePar
         for (var i = 0; i < likeCols.length; i++) {
             conditions.push(likeCols[i] + " LIKE ?");
             params.push(`%${search}%`);
+        }
+
+        // 암호화 필드(이름·전화 등) 정확일치 검색: blind-index 컬럼 = blindIndex(검색어)
+        const biCols = blindIndexColumns[table] || [];
+        if (biCols.length > 0) {
+            const bi = blindIndex(search);
+            for (var b = 0; b < biCols.length; b++) {
+                conditions.push(biCols[b] + " = ?");
+                params.push(bi);
+            }
         }
 
         // FULLTEXT 설정 없는 테이블은 기존 LIKE 방식 유지

--- a/utils.js/search-columns.js
+++ b/utils.js/search-columns.js
@@ -29,3 +29,12 @@ export const likeOnlyColumns = {
     // 회원검색 평문축: 아이디(user_name) · 닉네임(nickname). 이름·전화는 암호화되어 부분검색 불가.
     'users': ['users.user_name', 'users.nickname'],
 }
+
+// 암호화 필드의 blind-index(정확일치) 검색 컬럼.
+//  검색어를 blindIndex()로 변환해 '=' 로 매칭 → 암호화된 이름·전화도 '정확일치' 검색 가능.
+//  (부분검색은 불가. 전화는 하이픈/공백 무시, 이름은 대소문자 무시로 정규화됨.)
+//  ※ 대상 컬럼은 PII_FIELDS(pii.js)의 idx 매핑과 동일. 값은 encForSave 저장 시/백필로 채워짐.
+export const blindIndexColumns = {
+    'transactions': ['transactions.buyer_name_idx', 'transactions.buyer_phone_idx'],
+    'users': ['users.name_idx', 'users.phone_idx'],
+}


### PR DESCRIPTION
암호화(Phase 4)로 이름·전화 '부분검색'이 불가해진 것을 보완. 검색어를 blindIndex()로 변환해 암호화 필드의 idx 컬럼과 '=' 매칭하여 '정확일치' 검색을 지원.
(전화는 하이픈/공백 무시, 이름은 대소문자 무시로 정규화됨. 부분검색은 여전히 불가.)
- search-columns.js: blindIndexColumns 추가 (주문 buyer_name_idx·buyer_phone_idx / 회원 name_idx·phone_idx)
- query-util.js: 검색 조건에 blind-index '=' 매칭 추가 (평문 축 LIKE와 OR 결합) ※ 암호화 이전 기존 행이 검색되려면 idx 백필 필요: node scripts/pii-backfill.js