### PR TITLE
brand get() 행 없음 가드 — 존재하지 않는 id 조회 시 500 크래시 대신 명확 응답+로그

### DIFF
--- a/controllers/brand.controller.js
+++ b/controllers/brand.controller.js
@@ -66,6 +66,11 @@ const brandCtrl = {
       const { id } = req.params;
       let data = await readPool.query(`SELECT * FROM ${table_name} WHERE id=?`, [id]);
       data = data[0][0];
+      // 행 없음 가드: id에 해당하는 브랜드가 없으면 500 크래시 대신 명확히 응답 + 로그.
+      if (!data) {
+        logger.error(`brand get: not found id=${id}`);
+        return response(req, res, -200, `브랜드 정보를 불러오지 못했습니다. (id=${id})`, false);
+      }
       data["theme_css"] = JSON.parse(data?.theme_css ?? "{}");
       //data["slider_css"] = JSON.parse(data?.slider_css ?? "{}");
       data["setting_obj"] = JSON.parse(data?.setting_obj ?? "{}");


### PR DESCRIPTION
기본정보 화면이 데이터를 못 불러오던 원인. `SELECT * FROM brands WHERE id=?`가 0행이면 data[0][0]가 undefined인데 theme_css 등을 세팅하다 'Cannot set properties of undefined'로 500이 발생했음. 이제 행이 없으면 로그(`brand get: not found id=`)를 남기고 -200으로 응답.