### PR TITLE
seller_products 카테고리 필터 dual-read (마이그레이션 브랜드 셀러 대비)

### DIFF
--- a/controllers/seller_products.controller.js
+++ b/controllers/seller_products.controller.js
@@ -151,8 +151,9 @@ const sellerProductsCtrl = {
                                 seller_categories.unshift(category_ids.join())
                             }
                             let catIds = seller_categories.join().split(',');
-                            sql += ` AND category_id0 IN (${catIds.map(() => '?').join(',')})`;
-                            params.push(...catIds);
+                            // dual-read(단계 이행): 연결테이블(products_categories) OR 위치컬럼 category_id0
+                            sql += ` AND (products.id IN (SELECT product_id FROM products_categories WHERE category_id IN (${catIds.map(() => '?').join(',')}) AND is_delete=0) OR category_id0 IN (${catIds.map(() => '?').join(',')}))`;
+                            params.push(...catIds, ...catIds);
                         }
                     }
 
@@ -178,8 +179,9 @@ const sellerProductsCtrl = {
                                 seller_categories.unshift(category_ids.join())
                             }
                             let catIds2 = seller_categories.join().split(',');
-                            sql += ` AND category_id0 IN (${catIds2.map(() => '?').join(',')})`;
-                            params.push(...catIds2);
+                            // dual-read(단계 이행): 연결테이블 OR 위치컬럼 category_id0
+                            sql += ` AND (products.id IN (SELECT product_id FROM products_categories WHERE category_id IN (${catIds2.map(() => '?').join(',')}) AND is_delete=0) OR category_id0 IN (${catIds2.map(() => '?').join(',')}))`;
+                            params.push(...catIds2, ...catIds2);
                             let brandIds2 = String(decode_user?.seller_brand).split(',');
                             sql += ` AND category_id1 IN (${brandIds2.map(() => '?').join(',')}) `;
                             params.push(...brandIds2);


### PR DESCRIPTION
셀러 상품목록의 seller_category 필터를 연결테이블 OR 위치컬럼(category_id0)으로 보강. 마이그레이션 브랜드에서 셀러 카테고리 필터가 깨지지 않도록. seller_brand(category_id1)는 dual-write 로 동작하므로 유지(브랜드→속성 셀러 이전은 후속).