### PR TITLE
가입 형식 검증 + 수신동의 저장

### DIFF
--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -1,6 +1,6 @@
 'use strict';
 import { checkIsManagerUrl, differenceTwoDate, generateRandomCode, returnMoment } from "../utils.js/function.js";
-import { insertQuery, updateQuery } from "../utils.js/query-util.js";
+import { insertQuery, updateQuery, hasColumn } from "../utils.js/query-util.js";
 import { createHashedPassword, checkLevel, makeUserToken, response, checkDns, lowLevelException } from "../utils.js/util.js";
 import { encForSave, decRow, decRows, blindIndex } from "../utils.js/pii.js";
 import { isShopgoBrand } from "../utils.js/is-shopgo.js";
@@ -96,6 +96,12 @@ const makeUserTokenPayload = (user, agent) => ({
     // 보안질문 설정 여부(1/0). 프론트 '보안질문 설정하기' 배너 노출 판단용.
     // ⚠ 값이 아니라 '설정됐는지'만 담는다(질문 id 는 토큰에 넣지 않는다).
     has_security_question: (user.security_question_id === null || user.security_question_id === undefined) ? 0 : 1,
+
+    // 수신동의 — 회원정보수정 화면이 현재 상태를 체크박스에 표시해야 한다.
+    // 컬럼이 아직 없는 환경(마이그레이션 전)에서는 undefined 가 되므로 0 으로 떨어뜨린다.
+    is_marketing_agree: user.is_marketing_agree ? 1 : 0,
+    is_sms_agree: user.is_sms_agree ? 1 : 0,
+    is_email_agree: user.is_email_agree ? 1 : 0,
 });
 
 // 토큰 쿠키 발급. signIn 의 res.cookie 옵션과 100% 동일해야 한다.
@@ -229,6 +235,36 @@ const authCtrl = {
             if (!user_pw) {
                 return response(req, res, -100, "비밀번호를 입력해 주세요.", {});
             }
+            // ── 아이디·비밀번호·휴대폰 형식 검증 ────────────────────────────────
+            // 예전엔 위 '비밀번호 입력 여부' 하나가 전부였다. 프론트 가입폼에도 형식 검증이
+            // 없어서 한 글자 아이디·한 글자 비밀번호가 그대로 만들어졌고, API 를 직접
+            // 호출하면 어떤 값이든 통과했다(가입폼은 우회할 수 있으므로 여기가 실제 관문이다).
+            //
+            // 규칙은 프론트 utils/function.js 의 validateSignUpInput 과 같은 값을 유지할 것.
+            // 이 검사는 신규 가입에만 걸린다 — 기존 회원 로그인·정보수정에는 영향이 없다.
+            const signup_id = String(user_name ?? '').trim();
+            if (signup_id.length < 4 || signup_id.length > 20) {
+                return response(req, res, -100, "아이디는 4~20자로 입력해 주세요.", {});
+            }
+            if (!/^[a-z0-9_]+$/.test(signup_id)) {
+                return response(req, res, -100, "아이디는 영문 소문자·숫자·밑줄(_)만 사용할 수 있습니다.", {});
+            }
+            if (String(user_pw).length < 8 || String(user_pw).length > 20) {
+                return response(req, res, -100, "비밀번호는 8~20자로 입력해 주세요.", {});
+            }
+            if (String(user_pw).toLowerCase() === signup_id.toLowerCase()) {
+                return response(req, res, -100, "비밀번호를 아이디와 다르게 입력해 주세요.", {});
+            }
+            // 휴대폰번호는 아이디 찾기·주문 연락에 쓰인다. 숫자 9~11자리만 통과시킨다
+            // (형식 강제가 아니라 명백히 잘못된 값만 거른다).
+            if (phone_num) {
+                const phone_digits = String(phone_num).replace(/[^0-9]/g, '');
+                if (phone_digits.length < 9 || phone_digits.length > 11) {
+                    return response(req, res, -100, "휴대폰번호를 정확히 입력해 주세요.", {});
+                }
+            }
+            // 아래 로직은 정제된 아이디를 쓴다(앞뒤 공백이 그대로 저장돼 로그인이 안 되던 것 방지).
+            user_name = signup_id;
             // shopgo 본사(brands.id=98)와 그 하위 가맹점(brands.parent_id=98)만 보안질문 필수.
             // → 본사 스토어프론트(shopgo.co.kr)에서 가입하는 일반 회원도 보안질문 선택+답변이 필수가 된다.
             // 그 외 브랜드는 값이 와도 무시 → 기존 동작 100% 불변.
@@ -286,6 +322,26 @@ const authCtrl = {
                 }
             }
 
+            // ── 수신동의 ────────────────────────────────────────────────────
+            // 가입폼의 '쇼핑정보/SMS/이메일 수신 동의' 체크박스는 값이 전송조차 되지 않았고
+            // 받을 컬럼도 없었다(고객에게는 '회원정보수정에서 언제든 변경 가능'이라고
+            // 안내하면서 그 화면엔 항목이 없었다). 이제 실제로 저장한다.
+            //
+            // 컬럼이 아직 없을 수 있으므로(마이그레이션 전 배포) hasColumn 으로 감싼다 —
+            // 없으면 이 필드들만 빼고 저장하며 가입 자체는 그대로 성공한다.
+            let marketing_fields = {};
+            if (await hasColumn('users', 'is_marketing_agree')) {
+                const on = (v) => (v == 1 || v === true || v === 'true') ? 1 : 0;
+                const marketing = on(req.body?.is_marketing_agree);
+                marketing_fields = {
+                    is_marketing_agree: marketing,
+                    is_sms_agree: on(req.body?.is_sms_agree),
+                    is_email_agree: on(req.body?.is_email_agree),
+                    // 동의 사실만으로는 부족하다 — 언제 동의했는지도 남긴다.
+                    marketing_agreed_at: marketing ? returnMoment() : null,
+                };
+            }
+
             user_pw = pw_data.hashedPassword;
             let user_salt = pw_data.salt;
             let obj = {
@@ -310,7 +366,8 @@ const authCtrl = {
                 shareholder_img,
                 register_img,
                 seller_id,
-                ...security_fields
+                ...security_fields,
+                ...marketing_fields
             }
 
             obj = encForSave('users', obj); // 실명·전화 암호화 + blind-index (신규 security_* 키는 그대로 통과)
@@ -401,6 +458,22 @@ const authCtrl = {
                     return response(req, res, -100, "인증시간이 지났습니다. 다시 인증해 주세요.", false)
                 }
             }
+            // 수신동의 — 가입 안내문이 '회원정보수정에서 언제든 변경 가능'이라고 약속하는 항목이다.
+            // 보내온 경우에만 반영한다(이 API 를 부르는 다른 화면들이 값을 안 보내는데,
+            // 무조건 덮으면 닉네임만 바꿔도 동의가 꺼져 버린다).
+            let marketing_update = {};
+            if (await hasColumn('users', 'is_marketing_agree')) {
+                const on = (v) => (v == 1 || v === true || v === 'true') ? 1 : 0;
+                if ('is_marketing_agree' in req.body) {
+                    const marketing = on(req.body?.is_marketing_agree);
+                    marketing_update.is_marketing_agree = marketing;
+                    // 껐다 켜면 시각을 새로 남기고, 끄면 비운다.
+                    marketing_update.marketing_agreed_at = marketing ? returnMoment() : null;
+                }
+                if ('is_sms_agree' in req.body) marketing_update.is_sms_agree = on(req.body?.is_sms_agree);
+                if ('is_email_agree' in req.body) marketing_update.is_email_agree = on(req.body?.is_email_agree);
+            }
+
             let result = await updateQuery('users', encForSave('users', {
                 nickname,
                 phone_num,
@@ -413,7 +486,8 @@ const authCtrl = {
                 contract_img,
                 bsin_lic_img,
                 shareholder_img,
-                register_img
+                register_img,
+                ...marketing_update
             }), decode_user?.id); // phone_num 암호화 + phone_idx 세팅(부분 업데이트 안전, name 없음)
 
             // 토큰 재발급 — payload 에 nickname·phone_num·profile_img 가 들어 있어서

--- a/migrations/2026-08-10_users_marketing_agree.sql
+++ b/migrations/2026-08-10_users_marketing_agree.sql
@@ -1,0 +1,52 @@
+-- ============================================================================
+-- 회원 수신동의 저장 컬럼
+-- 날짜: 2026-08-10
+--
+-- 왜 필요한가:
+--   가입 폼(프레임1·2·3)에 '쇼핑정보 수신 동의 / SMS 수신 동의 / 이메일 수신 동의'
+--   체크박스가 있는데, 이 값들은 **어디에도 저장되지 않았다** — 가입 요청 바디에
+--   아예 실리지 않았고 받을 컬럼도 없었다.
+--   게다가 그 아래 안내문은 '회원가입 후 회원정보수정 페이지에서 언제든지 수신여부를
+--   변경하실 수 있습니다' 라고 적혀 있었는데, 그 화면에는 해당 항목 자체가 없었다.
+--   즉 고객에게는 지키지 않는 약속이 표시되고 있었다.
+--
+--   광고성 정보를 보내려면 동의 사실과 시점을 남겨야 한다(정보통신망법 제50조).
+--   지금은 문자·메일 발송 수단이 없지만, 동의 기록은 발송 여부와 무관하게 남겨야
+--   나중에 채널이 생겼을 때 소급해서 물어보지 않아도 된다.
+--
+-- 안전성:
+--   · 컬럼 추가만 한다(기존 행은 전부 0 = 미동의). 데이터 변경·삭제 없음.
+--   · 코드에는 hasColumn 가드가 있어 이 마이그레이션 전에 배포해도 동작한다
+--     (컬럼이 없으면 해당 값을 빼고 저장한다). 반대 순서도 안전하다.
+--   ⚠ 실행 후 백엔드 재시작 필요 — hasColumn 은 결과를 프로세스 단위로 캐시한다.
+--
+-- 실행 전 백업(공유 DB 이므로 권장):
+--   mysqldump -u <user> -p <db> users > users_backup_20260810.sql
+-- ============================================================================
+
+-- ── 0) 이미 있는지 확인 (먼저 이것만 돌려볼 것) ───────────────────────────
+-- SELECT COLUMN_NAME FROM information_schema.COLUMNS
+--  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'users'
+--    AND COLUMN_NAME IN ('is_marketing_agree','is_sms_agree','is_email_agree','marketing_agreed_at');
+
+-- ── 1) 컬럼 추가 ────────────────────────────────────────────────────────────
+ALTER TABLE users
+  ADD COLUMN is_marketing_agree TINYINT(1) NOT NULL DEFAULT 0 COMMENT '쇼핑정보(광고성) 수신 동의',
+  ADD COLUMN is_sms_agree       TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'SMS 수신 동의',
+  ADD COLUMN is_email_agree     TINYINT(1) NOT NULL DEFAULT 0 COMMENT '이메일 수신 동의',
+  -- 동의 '시점'도 남긴다. 분쟁 시 동의 사실만으로는 부족하다.
+  ADD COLUMN marketing_agreed_at DATETIME NULL DEFAULT NULL COMMENT '수신동의를 마지막으로 켠 시각';
+
+-- ── 2) 실행 후 확인 — 4행이 나와야 한다 ─────────────────────────────────────
+-- SELECT COLUMN_NAME, COLUMN_TYPE, COLUMN_DEFAULT FROM information_schema.COLUMNS
+--  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'users'
+--    AND COLUMN_NAME IN ('is_marketing_agree','is_sms_agree','is_email_agree','marketing_agreed_at');
+
+-- ============================================================================
+-- 롤백:
+--   ALTER TABLE users
+--     DROP COLUMN is_marketing_agree,
+--     DROP COLUMN is_sms_agree,
+--     DROP COLUMN is_email_agree,
+--     DROP COLUMN marketing_agreed_at;
+-- ============================================================================


### PR DESCRIPTION
· signUp 에 아이디·비밀번호·휴대폰 형식 검증 추가. 예전엔 '비밀번호를 입력했는가'
  하나가 전부여서 API 를 직접 부르면 한 글자 아이디도 통과했다(프론트 가입폼에도
  검증이 없었다 — 같은 규칙을 프론트 validateSignUpInput 에 넣었다).
  아이디는 앞뒤 공백을 다듬어 저장한다(공백이 붙어 저장돼 로그인이 안 되던 것 방지).

· 수신동의(쇼핑정보/SMS/이메일)를 실제로 저장한다 — 값이 전송되지도, 받을 컬럼도
  없었는데 가입 화면은 '회원정보수정에서 언제든 변경 가능'이라고 안내하고 있었다.
  동의 시각(marketing_agreed_at)도 함께 남긴다. 정보수정에서는 '보내온 값만' 덮는다
  (다른 화면들이 이 필드를 안 보내는데 무조건 덮으면 닉네임만 바꿔도 동의가 꺼진다).
  토큰 payload 에 현재 동의 상태를 실어 화면이 체크 상태를 표시할 수 있게 했다.

  ⚠ migrations/2026-08-10_users_marketing_agree.sql 실행 + 백엔드 재시작 필요.
    hasColumn 가드가 있어 마이그레이션 전에 배포해도 가입은 그대로 동작한다.