### PR TITLE
상품 저장이 구글 번역을 기다리던 것을 대기열로 돌린다

### DIFF
--- a/controllers/product.controller.js
+++ b/controllers/product.controller.js
@@ -714,10 +714,23 @@ const productCtrl = {
             dns_data = dns_data[0][0];
             dns_data["setting_obj"] = JSON.parse(dns_data?.setting_obj ?? "{}");
 
-            let langs = await settingLangs(lang_obj_columns[table_name], obj, dns_data, table_name, result?.insertId, true);
-            if (langs?.lang_obj) {
-                await updateQuery(table_name, { lang_obj: langs.lang_obj }, result?.insertId);
-            }
+            // 번역은 큐에 담고 스케줄러가 처리한다(마지막 인자 생략 = is_process false).
+            //
+            // 예전엔 여기서 true 를 넘겨 그 자리에서 구글 번역을 돌렸다. 번역 대상 컬럼 4개
+            // (product_name·product_comment·product_spec·product_description) × 켜진 언어 4개가
+            // 3중 for+await 로 중첩돼 있고 번역 경로에 Promise.all 이 한 개도 없어서,
+            // 상품 1건 저장에 구글 왕복이 12회(상세설명 없음) ~ 40회(8,000자) 직렬로 쌓였다.
+            // 회당 timeout 은 20초인데 전체 데드라인이 없어 상한도 없었다.
+            // 그동안 응답이 안 나가므로 가맹점 화면은 저장 버튼을 누른 채 수 초~수십 초 멈춰 있었다.
+            // ("상품 추가가 오래 걸린다"는 가맹점 의견의 실체가 이것이다)
+            //
+            // 게시글·카테고리 컨트롤러는 원래부터 인자를 생략해 전부 큐로 보내고 있었다 —
+            // 상품만 예외였다. 같은 방식으로 되돌린다.
+            //
+            // 반영 시점: 스케줄러가 1분마다 큐를 비우므로 보통 저장 후 1~2분 내에 채워진다.
+            // 그 사이 화면이 비지는 않는다 — 프론트 formatLang 이 번역이 없으면 원문으로 폴백하므로
+            // 한국어 화면은 무변화이고, 그 시간에 외국어로 보는 고객에게만 원문이 보인다.
+            await settingLangs(lang_obj_columns[table_name], obj, dns_data, table_name, result?.insertId);
 
 
             if (!result?.insertId) {
@@ -946,10 +959,10 @@ const productCtrl = {
             dns_data = dns_data[0][0];
             dns_data["setting_obj"] = JSON.parse(dns_data?.setting_obj ?? "{}");
 
-            let langs = await settingLangs(lang_obj_columns[table_name], obj, dns_data, table_name, id, true);
-            if (langs?.lang_obj) {
-                await updateQuery(table_name, { lang_obj: langs.lang_obj }, id);
-            }
+            // 수정도 저장과 같은 이유로 큐에 담는다(create 쪽 주석 참고).
+            // 큐의 else 분기가 같은 (table_name, item_id) 행을 먼저 지우고 새로 넣으므로,
+            // 한 상품을 여러 번 저장해도 대기열에 중복으로 쌓이지 않는다.
+            await settingLangs(lang_obj_columns[table_name], obj, dns_data, table_name, id);
 
             const product_id = id;
             //option


### PR DESCRIPTION
[증상] 가맹점 의견 "상품 추가가 상당히 오래 걸린다".

[원인] create/update 가 settingLangs 의 마지막 인자로 true(=지금 번역)를 넘겨, 응답을 내보내기 전에 구글 번역 API 를 인라인·완전 직렬로 호출했다.
  · 번역 대상 컬럼 4개(product_name·product_comment·product_spec·product_description)
    × 켜진 언어 4개(en·ja·cn·es) 가 3중 for+await 로 중첩
  · 번역 경로(util.js)에 Promise.all 이 한 개도 없다
  · product_description 은 HTML 이라 1200자 청크마다 별도 왕복이 더 붙는다
결과: 상품 1건 저장에 구글 왕복이 12회(상세설명 없음) ~ 40회(8,000자) 직렬. 회당 timeout 20초인데 전체 데드라인이 없어 상한도 없었다.

게시글·카테고리 컨트롤러(post / post_category / product_category / product_category_group, 8곳)는 원래부터 인자를 생략해 전부 대기열로 보낸다 — 상품만 예외였다. 같은 방식으로 되돌린다.

[범위] settingLangs 는 setting_obj.is_use_lang != 1 이면 즉시 return 하므로 언어팩이 꺼진 브랜드는 원래 영향이 없다. 다만 가맹점 승인 시 브랜드를 자동 생성하는
merchant_application.controller.js:267 이 is_use_lang:'1' + 5개국을 하드코딩하고 비교가 느슨한 != 1 이라 문자열 '1' 도 통과한다 — 즉 신규 개설 가맹점은 기본 ON 이다. "언어팩 켠 일부"가 아니라 사실상 대부분이 겪던 지연이다.

[반영 시점] 스케줄러가 1분 주기로 대기열을 비운다(schedules/index.js). 운영 로그에서 가동 확인함: 2026-08-10 07:04·07:05 `[lang] 처리 완료 ... 엔진=공식API`. (winston 은 production 에서 Console transport 를 붙이지 않으므로 pm2 logs 가 아니라
 ~/back/logs/YYYY-MM-DD.log 를 봐야 한다)

[함께 고친 것 — 프론트]
대기열로 미루면 lang_obj 의 ko 슬롯이 원본 컬럼보다 뒤처지는 창이 생긴다.
formatLang 이 ko 슬롯을 우선하고 있어서, 상품명을 고친 뒤 1~2분 동안
**한국어 화면에 옛 이름이 뜰 수 있었다.** ko 는 정의상 원문 사본이므로
원문 언어일 때는 lang_obj 를 보지 않고 컬럼 값을 쓰도록 바꿨다.
(게시글·카테고리는 원래 대기열이라 같은 창이 이미 있었다 — 함께 해소된다)

검증: 백엔드 파싱 OK / 프론트 SWC 1198개 0실패 · next build 성공
     formatLang 단위테스트 21건 신규 · 기존 i18n 28건 통과