### PR TITLE
게시판 목록에 브랜드 스코프 · 권한 거부를 HTTP 403 으로

### DIFF
--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -70,6 +70,14 @@ const postCtrl = {
             sql += ` LEFT JOIN post_categories ON ${table_name}.category_id=post_categories.id `
             sql += ` WHERE ${table_name}.parent_id=-1 `
             let params = [];
+            // ⚠ 브랜드 스코프는 무조건 건다.
+            //
+            // 예전엔 브랜드 조건이 아예 없었고, 좁히는 건 아래 `if (category_id)` 하나뿐이었다.
+            // 즉 category_id 를 빼고 부르면 **전 가맹점의 글**이 한 번에 나왔다(직원 레벨10 이상).
+            // 글은 게시판(post_categories)을 통해 브랜드에 속하므로 그 조인으로 스코프를 건다.
+            // (LEFT JOIN 이지만 이 조건이 붙으면 사실상 INNER — 카테고리 없는 글은 목록 대상이 아니다)
+            sql += ` AND post_categories.brand_id=? `
+            params.push(decode_dns?.id ?? 0);
             if (category_id) {
                 sql += ` AND ${table_name}.category_id IN (${category_ids.map(() => '?').join(',')}) `
                 params.push(...category_ids);

--- a/utils.js/util.js
+++ b/utils.js/util.js
@@ -118,7 +118,14 @@ export const response = async (req, res, code, message, data) => { //응답 포�
         return resDict;
     } else {
         if (code < 0) {
-            res.status(500).send(resDict)
+            // 실패 코드는 지금까지 전부 HTTP 500 이었다. '권한이 없습니다'(-150)도 마찬가지라,
+            // 로그인 전에 화면이 부르는 조회 하나하나가 서버 오류로 잡혀 5xx 지표를 오염시켰다.
+            // 권한 거부는 서버 잘못이 아니므로 403 으로 내린다.
+            //
+            // 프론트 동작은 그대로다 — axios 는 2xx 가 아니면 어느 코드든 reject 하고,
+            // 인터셉터가 응답 본문을 그대로 넘기므로 화면에 뜨는 메시지도 같다(utils/axios.js).
+            // 나머지 실패 코드는 이번 범위가 아니라 500 그대로 둔다.
+            res.status(code === -150 ? 403 : 500).send(resDict)
         } else {
             res.status(200).send(resDict)
         }


### PR DESCRIPTION
■ 게시판 목록(/api/posts)에 브랜드 조건이 없었다
posts 를 좁히는 조건이 `if (category_id)` 하나뿐이라, category_id 를 빼고 부르면 **전 가맹점의 글**이 한 번에 나왔다. 직원(레벨10 이상)만 닿는 경로지만 가맹점 사이는 넘지 말아야 할 선이다. 글은 게시판(post_categories)을 통해 브랜드에 속하므로 그 조인으로 스코프를 무조건 건다.

프론트에서 `category_id=null` 같은 문자열을 보내던 것을 고치는 중에 발견했다 — 그 값이 truthy 라 우연히 좁혀지고 있었을 뿐이고, 제대로 빼는 순간 열리는 자리였다.

■ 권한 거부가 HTTP 500 이었다
response() 가 실패 코드를 전부 500 으로 내려서, 로그인 전에 화면이 부르는 조회 하나하나가 서버 오류로 잡혔다(오늘만 15건). 권한 거부는 서버 잘못이 아니므로
-150 만 403 으로 내린다. 나머지 실패 코드는 이번 범위가 아니라 그대로 둔다.

프론트 동작은 같다 — axios 는 2xx 가 아니면 어느 코드든 reject 하고 인터셉터가 응답 본문을 그대로 넘기므로 화면에 뜨는 메시지도 바뀌지 않는다.